### PR TITLE
updated README to correct path to angular-latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ bower install
 Install latest version of Angular
 
 ```bash
-$ cd app/components/angular-latest && npm install
+$ cd app/bower_components/angular-latest && npm install
 ```
 
 Finally build latest version of Angular


### PR DESCRIPTION
While going through the Prototypo installation I found that the path to angular-latest was incorrect. I just updated the README to reflect the correct path. 
