### PR TITLE
Fix browser sniffing for IE11 (fixes #141)

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -95,7 +95,8 @@ angular.module('prototypoApp', [
 			// detect incompatible browsers
 			if ( 
 				(jQuery.browser.chrome && parseFloat( jQuery.browser.version ) < 30) ||
-				(jQuery.browser.mozilla && parseFloat( jQuery.browser.version ) < 25) ||
+				(jQuery.browser.mozilla && parseFloat(jQuery.browser.version) < 25
+					&& (!navigator.userAgent.match(/Trident\/7\./))) ||
 				(jQuery.browser.msie && parseFloat( jQuery.browser.version ) < 11) ||
 				(jQuery.browser.safari && parseFloat( jQuery.browser.version ) < 536) 
 			) {


### PR DESCRIPTION
Fix for browser detection so IE11 isn't detected as Firefox 11 (short term fix for #141, recommend moving to feature detection).
