### PR TITLE
advancewidth update

### DIFF
--- a/app/scripts/components/handlegrip/handlegrip-text.components.jsx
+++ b/app/scripts/components/handlegrip/handlegrip-text.components.jsx
@@ -94,6 +94,12 @@ export default class HandlegripText extends React.Component {
 		handlegripDOM.addEventListener('mousemove', this.handleMove);
 	}
 
+	componentDidUpdate(prevProps, prevState) {
+		if ((prevState.fontValues !== this.state.fontValues) && !this.state.tracking) {
+			this.dispatchAdvancewidthFromFontinstance();
+		}
+	}
+
 	componentWillUnmount() {
 		const handlegripDOM = ReactDOM.findDOMNode(this);
 
@@ -251,11 +257,20 @@ export default class HandlegripText extends React.Component {
 	}
 
 	dispatchAllFromFontinstance() {
-		// get the new advanceWidth of the current glyph
+		// get the new properties of the current glyph
 		// directly from the globaly available font instance
 		this.client.dispatchAction('/update-letter-spacing-value', {
 			letter: this.getSelectedLetter(),
 			valueList: ['advanceWidth', 'spacingLeft', 'spacingRight'],
+		});
+	}
+
+	dispatchAdvancewidthFromFontinstance() {
+		// get the new advanceWidth of the current glyph
+		// directly from the globaly available font instance
+		this.client.dispatchAction('/update-letter-spacing-value', {
+			letter: this.getSelectedLetter(),
+			valueList: ['advanceWidth'],
 		});
 	}
 


### PR DESCRIPTION
added an advancewidth update for letterspacing when a font prop has changed

I tried to avoid unnecessary action dispatch but as @yannickmathey told me, you cannot check accurately if a font property update will change advancewidth or not. I'll leave @FranzPoize to see if there is a better approach for advancewidth update handling

