### PR TITLE
Fix: loading button too fat

### DIFF
--- a/app/scripts/components/credits-export.components.jsx
+++ b/app/scripts/components/credits-export.components.jsx
@@ -129,7 +129,7 @@ export default class CreditsExport extends React.Component {
 				<form className="sign-in-form" onSubmit={this.handleSubmit}>
 					<AddCard ref="card" inError={this.state.inError}/>
 					{errors}
-					<div className="add-family-form-buttons">
+					<div className="action-form-buttons">
 						<Button click={this.exit} label="Cancel" neutral={true}/>
 						<Button click={this.handleSubmit} label={`Buy 5 credits for 5 ${currency}`} loading={this.state.loading}/>
 					</div>

--- a/app/scripts/components/export-as.components.jsx
+++ b/app/scripts/components/export-as.components.jsx
@@ -46,7 +46,7 @@ export default class ExportAs extends React.Component {
 							<InputWithLabel label="Variant name" ref="variant"/>
 						</div>
 					</div>
-					<div className="add-family-form-buttons">
+					<div className="action-form-buttons">
 						<Button click={this.exit} label="Cancel" neutral={true}/>
 						<Button click={this.exportAs} label="Export"/>
 					</div>

--- a/app/scripts/components/familyVariant/add-family-variant.components.jsx
+++ b/app/scripts/components/familyVariant/add-family-variant.components.jsx
@@ -118,7 +118,7 @@ export class AddFamily extends React.Component {
 					<label className="add-family-form-label"><span className="add-family-form-label-order">2. </span>Choose a family name</label>
 					<input ref="name" className="add-family-form-input" type="text" placeholder="My new typeface"></input>
 					{error}
-					<div className="add-family-form-buttons">
+					<div className="action-form-buttons">
 						<Button click={(e) => {this.exit(e);} } label="Cancel" neutral={true}/>
 						<Button click={(e) => {this.createFont(e);} } label="Create family"/>
 					</div>
@@ -222,7 +222,7 @@ export class AddVariant extends React.Component {
 					placeholder="Enter a variant name or choose a suggestion with predefined settings"
 					options={this.variants}/>
 				<div className="variant-error">{this.state.error}</div>
-				<div className="add-family-form-buttons">
+				<div className="action-form-buttons">
 					<Button click={(e) => {this.exit(e);} } label="Cancel" neutral={true}/>
 					<Button click={(e) => {this.createVariant(e);} } label="Create family"/>
 				</div>

--- a/app/scripts/components/familyVariant/change-name-family.components.jsx
+++ b/app/scripts/components/familyVariant/change-name-family.components.jsx
@@ -65,7 +65,7 @@ export default class ChangeNameFamily extends React.Component {
 				<div className="modal-container-content">
 					<InputWithLabel ref="newName" inputValue={this.props.family.name}/>
 					{error}
-					<div className="add-family-form-buttons">
+					<div className="action-form-buttons">
 						<Button click={this.exit} label="Cancel" neutral={true}/>
 						<Button click={this.editFamily} label="Change family name"/>
 					</div>

--- a/app/scripts/components/familyVariant/change-name-variant.components.jsx
+++ b/app/scripts/components/familyVariant/change-name-variant.components.jsx
@@ -66,7 +66,7 @@ export default class ChangeNameVariant extends React.Component {
 				<div className="modal-container-content">
 					<InputWithLabel ref="newName" inputValue={this.props.variant.name}/>
 					{error}
-					<div className="add-family-form-buttons">
+					<div className="action-form-buttons">
 						<Button click={this.exit} label="Cancel" neutral={true}/>
 						<Button click={this.editVariant} label="Change variant name"/>
 					</div>

--- a/app/scripts/components/familyVariant/duplicate-variant.components.jsx
+++ b/app/scripts/components/familyVariant/duplicate-variant.components.jsx
@@ -67,7 +67,7 @@ export default class DuplicateVariant extends React.Component {
 				<div className="modal-container-content">
 					<InputWithLabel ref="newName"/>
 					{error}
-					<div className="add-family-form-buttons">
+					<div className="action-form-buttons">
 						<Button click={this.exit} label="Cancel" neutral={true}/>
 						<Button click={this.duplicateVariant} label={`Duplicate ${this.props.variant.name}`}/>
 					</div>

--- a/app/scripts/components/shared/button.components.jsx
+++ b/app/scripts/components/shared/button.components.jsx
@@ -21,6 +21,7 @@ export default class Button extends React.Component {
 			dark: this.props.dark,
 			small: this.props.small,
 			'split-left': isSplitted,
+			loading: this.props.loading,
 		});
 		const splitRight = ClassNames({
 			'split-right': true,

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -68,6 +68,7 @@ import '../styles/components/shared/invoice.scss';
 import '../styles/components/shared/loading-overlay.scss';
 import '../styles/components/shared/button.scss';
 import '../styles/components/shared/modal.scss';
+import '../styles/components/shared/action-form-buttons.scss';
 import '../styles/components/toolbar/toolbar.scss';
 import '../styles/components/toolbar/arianne-thread.scss';
 import '../styles/components/toolbar/view-buttons.scss';

--- a/app/styles/components/collection/family.scss
+++ b/app/styles/components/collection/family.scss
@@ -141,16 +141,6 @@
 			justify-content: space-between;
 		}
 
-		&-buttons {
-			justify-content: flex-end;
-			display:flex;
-
-			& .button {
-				padding:10px 20px;
-				margin-left:10px;
-			}
-		}
-
 		&-error {
 			width: 100%;
 			text-align: center;

--- a/app/styles/components/shared/action-form-buttons.scss
+++ b/app/styles/components/shared/action-form-buttons.scss
@@ -1,0 +1,14 @@
+.action-form-buttons {
+	justify-content: flex-end;
+	display:flex;
+
+	& .button {
+		padding:10px 20px;
+		margin-left:10px;
+
+		&.loading {
+			padding-top: 5px;
+			padding-bottom: 5px;
+		}
+	}
+}


### PR DESCRIPTION
Before 
![before](https://cloud.githubusercontent.com/assets/969003/19565984/14f7165c-96e9-11e6-8678-eb8d7cdfc408.PNG)
After
![after](https://cloud.githubusercontent.com/assets/969003/19565983/14f4c46a-96e9-11e6-97c7-073f648902c3.PNG)

At the same time, I saw that `add-family-form-buttons` was used a lot outside of the actual Add Family form, so I decided to extract that part to something common.
