### PR TITLE
Added an hover effect to the prototypo icon

### DIFF
--- a/app/images/icon-back-hover-reversed.svg
+++ b/app/images/icon-back-hover-reversed.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#24D390;}
+</style>
+<path class="st0" d="M4.4,13.4c0,1.9,1.7,3.7,4.6,4.7c0,0,0.1,0,0.1,0c0.1,0,0.2-0.1,0.3-0.2c0.1-0.1,0-0.3-0.1-0.4
+	C7.8,16.9,7,16,7,15c0-1.7,2.3-3.1,5.5-3.3l0,1.6c0,0.2,0.1,0.4,0.3,0.5c0,0,0.1,0,0.1,0c0,0,0.1,0,0.1,0l0,0c0.1,0,0.2,0,0.3-0.1
+	l4-3.5c0.1-0.1,0.2-0.3,0.2-0.4s-0.1-0.3-0.2-0.4l-4-3.5c-0.2-0.1-0.4-0.1-0.5,0c0,0-0.1,0.1-0.1,0.1c0,0,0,0,0,0c0,0,0,0.1-0.1,0.1
+	c0,0,0,0,0,0c0,0,0,0.1,0,0.1c0,0,0,0,0,0c0,0,0,0.1,0,0.1v0.8v0.8c0,0,0,0,0,0C7.8,8.4,4.4,10.7,4.4,13.4z"/>
+</svg>

--- a/app/images/icon-back-reversed.svg
+++ b/app/images/icon-back-reversed.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 22 22" style="enable-background:new 0 0 22 22;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#B3B3B3;}
+</style>
+<path class="st0" d="M4.4,13.4c0,1.9,1.7,3.7,4.6,4.7c0,0,0.1,0,0.1,0c0.1,0,0.2-0.1,0.3-0.2c0.1-0.1,0-0.3-0.1-0.4
+	C7.8,16.9,7,16,7,15c0-1.7,2.3-3.1,5.5-3.3l0,1.6c0,0.2,0.1,0.4,0.3,0.5c0,0,0.1,0,0.1,0c0,0,0.1,0,0.1,0l0,0c0.1,0,0.2,0,0.3-0.1
+	l4-3.5c0.1-0.1,0.2-0.3,0.2-0.4s-0.1-0.3-0.2-0.4l-4-3.5c-0.2-0.1-0.4-0.1-0.5,0c0,0-0.1,0.1-0.1,0.1c0,0,0,0,0,0c0,0,0,0.1-0.1,0.1
+	c0,0,0,0,0,0c0,0,0,0.1,0,0.1c0,0,0,0,0,0c0,0,0,0.1,0,0.1v0.8v0.8c0,0,0,0,0,0C7.8,8.4,4.4,10.7,4.4,13.4z"/>
+</svg>

--- a/app/scripts/components/account/account-dashboard.components.jsx
+++ b/app/scripts/components/account/account-dashboard.components.jsx
@@ -20,7 +20,9 @@ export default class AccountDashboard extends React.Component {
 
 		return (
 			<div className="account-dashboard">
-				<div className="account-dashboard-icon"/>
+				<Link to="/dashboard">
+					<div className="account-dashboard-icon"/>
+				</Link>
 				<Link to="/dashboard" className="account-dashboard-back-icon"/>
 				<div className="account-header">
 					<h1 className="account-title">{title}</h1>

--- a/app/scripts/components/collection/collection.components.jsx
+++ b/app/scripts/components/collection/collection.components.jsx
@@ -119,7 +119,7 @@ export default class Collection extends React.Component {
 		return (
 			<div className="collection">
 				<div className="collection-container">
-					<div className="account-dashboard-icon"/>
+					<div className="account-dashboard-icon" onClick={this.returnToDashboard}/>
 					<div className="account-dashboard-back-icon" onClick={this.returnToDashboard}/>
 					<div className="account-header">
 						<h1 className="account-title">My collection</h1>

--- a/app/styles/components/account/account-app.scss
+++ b/app/styles/components/account/account-app.scss
@@ -205,6 +205,15 @@
 		border: solid $green 10px;
 		top: -35px;
 		right: -35px;
+		transition: 0.8s;
+		transform-style: preserve-3d;
+		cursor: pointer;
+
+		&:hover {
+			transform:rotateY(180deg);
+			background-image: url("../../../images/icon-back-hover-reversed.svg");
+			background-color:$white;
+		}
 	}
 
 	&-back-icon {


### PR DESCRIPTION
Usually, the user looks for the back button on the top-right corner,  but on our full-screen modal there is the prototypo logo instead. While beeing quite stylish, it's not very functional and may leave the user confused.

I added an hover effect on this logo, morphing it into a back button if an user tries to find a way to go back over there. That's a trivial PR, I admit it, but it's a small QOL change that won't hurt anyone. 


![](http://g.recordit.co/XpF8f8exD0.gif)
