### PR TITLE
Fix value on undefined at registration

### DIFF
--- a/app/scripts/actions/user-lifecycle.actions.jsx
+++ b/app/scripts/actions/user-lifecycle.actions.jsx
@@ -430,7 +430,7 @@ export default {
 				}
 			});
 	},
-	'/sign-up': ({username, password, firstname, lastname, css, phone, skype, to, retry}) => {
+	'/sign-up': ({username, password, firstname, lastname, css = {}, phone, skype, to, retry}) => {
 		const toLocation = {
 			pathname: to || '/dashboard',
 		};


### PR DESCRIPTION
Since "css" (that we should change, it's more occupation, work or something like that) is not defined when the form is not filled, it fails and ends up in the catch, leaving the Hoodie user without a Stripe account.