### PR TITLE
Clear credits when signing out

### DIFF
--- a/app/scripts/actions/user-lifecycle.actions.jsx
+++ b/app/scripts/actions/user-lifecycle.actions.jsx
@@ -240,6 +240,10 @@ export default {
 		const patch = userStore.set('infos', {}).commit();
 
 		localServer.dispatchUpdate('/userStore', patch);
+
+		const prototypatch = prototypoStore.set('credits', 0).commit();
+
+		localServer.dispatchUpdate('/prototypoStore', prototypatch);
 	},
 	'/sign-in': async ({username, password, retry}) => {
 		const dashboardLocation = {


### PR DESCRIPTION
Step to reproduce :
1. Sign in and buy credits
2. Log out
3. Login / Create a new account, there is the same number of credits than before

This fixes that bug.