### PR TITLE
Fix: Change endpoint for 2 other free services

### DIFF
--- a/app/scripts/components/shared/with-country.components.js
+++ b/app/scripts/components/shared/with-country.components.js
@@ -15,14 +15,28 @@ const withCountry = component =>
 
 		async componentDidMount() {
 			try {
-				const response = await fetch('//freegeoip.net/json/');
+				const response = await fetch('//ipinfo.io/json');
 				const data = await response.json();
 
-				this.setState({country: data.country_code});
+				this.setState({country: data.country});
 			}
 			catch (err) {
 				// Failed to fetch can happen if the user has a blocker (ad, tracker...)
-				trackJs.track(`Error when getting the country: ${err.message}`);
+				window.trackJs.track(`Error when getting the country: ${err.message}`);
+
+				// trying another server just to be sure
+				try {
+					const response = await fetch('//get.geojs.io/v1/ip/country.json');
+					const data = await response.json();
+
+					this.setState({country: data.country});
+				}
+				catch (err2) {
+					// giving up
+					window.trackJs.track(
+						`Error when getting the country: ${err2.message}`,
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
https://freegeoip.net/json/ has deprecated and removed its endpoint, so we're moving to another one. 
Added an alternative if the first one has any problem.